### PR TITLE
Add functions that checks for conflicting zsh options and inverts them (also fixes #2)

### DIFF
--- a/composure.sh
+++ b/composure.sh
@@ -193,9 +193,9 @@ _zsh_shell_option_check ()
     typeset -x _composure_zsh_options
     _composure_zsh_options="$@"
 
-    for zsh_option in ${_composure_zsh_options[@]}; do
+    for zsh_option in "${_composure_zsh_options[@]}"; do
 
-      if $( setopt | command grep -qw "$zsh_option" ); then
+      if setopt | command grep -qw "$zsh_option"; then
 
         # since we need to invert the option (starts with no),
         # we must check first check if it actually starts with `no`
@@ -221,7 +221,7 @@ _reenable_zsh_options ()
 {
   # restablish the zsh option previous state
   if _zsh_shell_check; then
-    for zsh_option in ${_composure_zsh_options[@]}; do
+    for zsh_option in "${_composure_zsh_options[@]}"; do
       setopt $zsh_option
     done
     unset _composure_zsh_options


### PR DESCRIPTION
This PR basically consist on two parts:
- A collection of three functions that allows:
  - Check if zsh is running zsh
  - Invert a conflicting option
  - Re-enable the previous (if any) disabled options
- Disabling and re-enabling the `noclobber` option (in zsh) that makes the `draft`
  and `revise` to fail

I tried hard to make this PR as POSIX compliant as possible, but I'm not sure I fulfilled that objective.

Oh well, if you think needs improvement (no doubt it will), please tell me.
