### PR TITLE
Don't show a globbing error after initial install when there are no .inc files

### DIFF
--- a/composure.sh
+++ b/composure.sh
@@ -179,10 +179,7 @@ _generate_metadata_functions() {
 }
 
 _list_composure_files () {
-  typeset f
-  for f in $(_get_composure_dir)/*.inc; do
-    echo $f
-  done
+  find "$(_get_composure_dir)" -maxdepth 1 -name '*.inc'
 }
 
 _load_composed_functions () {


### PR DESCRIPTION
Before, after a new install, every new shell displays an error similar to
this, until a new function is composed:

```
-bash: $HOME/.local/composure/*.inc: No such file or directory
```
