### PR TITLE
Avoid an error on load when the composure dir does not yet exist

### DIFF
--- a/composure.sh
+++ b/composure.sh
@@ -179,7 +179,8 @@ _generate_metadata_functions() {
 }
 
 _list_composure_files () {
-  find "$(_get_composure_dir)" -maxdepth 1 -name '*.inc'
+  typeset composure_dir="$(_get_composure_dir)"
+  [ -d "$composure_dir" ] && find "$composure_dir" -maxdepth 1 -name '*.inc'
 }
 
 _load_composed_functions () {


### PR DESCRIPTION
HEAD^ resolved the problem in the scenario of having no *.inc files, but not
when there is no composure dir. This prevents an equally annoying error that
occurs when that directory has not yet been created.

I should have found this in my previous pull request, but failed to test on a "real" fresh server.
