### PR TITLE
use command substitution for fc correction check

### DIFF
--- a/composure.sh
+++ b/composure.sh
@@ -284,7 +284,7 @@ draft ()
   if [ -z "$num" ]; then
     typeset lines=1
     # some versions of 'fix command, fc' need corrective lenses...
-    fc -ln -1 | grep -q draft && lines=2
+    $(fc -ln -1 | grep -q draft) && lines=2
     # parse last command from fc output
     cmd=$(fc -ln -$lines | head -1 | sed 's/^[[:blank:]]*//')
   else


### PR DESCRIPTION
The check didn't work in bash v4.3.11(linux) or bash v4.3.25(osx).
Using Bash 3.2 or Zsh 5.0.6 everything worked fine.

This fixed it for me.
