### PR TITLE
Allow functions with metadata to run before load

### DIFF
--- a/composure.sh
+++ b/composure.sh
@@ -379,7 +379,7 @@ metafor ()
   # 'grep' for the metadata keyword, and then parse/filter the matching line
 
   # grep keyword # strip trailing '|"|; # ignore thru keyword and leading '|"
-  sed -n "/$keyword / s/['\";]*\$//;s/^[ 	]*$keyword ['\"]*\([^([].*\)*\$/\1/p"
+  sed -n "/$keyword / s/['\";]*\$//;s/^[ 	]*\(: _\)*$keyword ['\"]*\([^([].*\)*\$/\2/p"
 }
 
 reference ()


### PR DESCRIPTION
I haven't tested this much, but the idea is to allow me to define functions before (or without ever) loading `composure.sh`. We very much love this project, but we've run in to a circular dependency where we have to load `composure.sh` before even our logging functions since we use the metadata keywords *everywhere*. 

The idea here is to allow us to define a function with metadata keywords as usual, but that the functions will continue to run normally *before* we load `composure.sh`. This way, we can run normally and load normally and then later on when `composure.sh` gets loaded then `metafor()` will still be able to see and describe our functions.

This should require *no* changes to any existing projects or new projects.

---

There's two changes proposed here:
1. Extend the regular expression in `metafor()` to accept an optional `: _` prior to the keyword.
2. Use aliases in `cite()`, if available, instead of functions.

The change to `metafor()` means that I can put keywords like this:
```bash
function my_func()
{
    : _about "This is my function"
    do_some_other_stuff 
}
cite "about"
```
and then later `typeset -f my_func | metafor about` will see ": _about..." as matching the keyword "about" and show me the message.

The change to `cite()` is not required for this functionality, but it *slightly* improves performance and debugging by removing the empty function calls. (Aliases are captured by functions, so defining an alias prior to defining a function which calls that alias will result in the function including the _contents_ of the alias rather than the alias itself.) (This helps with DEBUG traps and with `set -x`.)

---

Thanks for making composure! 😃 
