### PR TITLE
cite: don't overwrite existing functions

### DIFF
--- a/composure.sh
+++ b/composure.sh
@@ -209,7 +209,7 @@ _generate_metadata_functions() {
   typeset f
   for f in $(_composure_keywords)
   do
-    eval "$f() { :; }"
+    type "$f" > /dev/null || eval "$f() { :; }"
   done
 }
 
@@ -275,7 +275,7 @@ cite ()
 
   typeset keyword
   for keyword in "$@"; do
-    eval "$keyword() { :; }"
+    type "$keyword" > /dev/null || eval "$keyword() { :; }"
   done
 }
 
@@ -516,7 +516,7 @@ echo "#!/usr/bin/env ${SHELL##*/}"
 cat <<END
 for f in $(_composure_keywords)
 do
-  eval "\$f() { :; }"
+  type "$f" >/dev/null || eval "\$f() { :; }"
 done
 unset f
 END


### PR DESCRIPTION
If a function already exists, don't overwrite it with the `{:;}` no-op. This is POSIX syntax, so should work everywhere.

(Basically, I was going to try to see if I could write a project-specific function to replace some of our meta keywords, but it would just get overwritten. E.g., it might be useful for some debug logging to make `about()` log something to a file when it's run.)