### PR TITLE
Use "||" after subshell in _transcribe

### DIFF
--- a/composure.sh
+++ b/composure.sh
@@ -155,9 +155,8 @@ _transcribe ()
               echo "composure stores your function definitions here" > README.txt
               git add README.txt
               git commit -m 'initial commit'
-            )
+            ) || _transcribe "$func" "$file" "$operation" "$comment"
             # if at first you don't succeed...
-            _transcribe "$func" "$file" "$operation" "$comment"
             valid=1
             ;;
           n|no|N|No|NO)


### PR DESCRIPTION
Comment `if at first you don't succeed...` says that we have to use recursion call just when an error occurred but in reality recursion call is always done.