### PR TITLE
v1.4.0: Improved metadata lookup

### DIFF
--- a/History.md
+++ b/History.md
@@ -1,4 +1,15 @@
-1.3   / 2015-11-04
+1.4.0 / 2022-04-04
+==================
+  * Reimplement `glossary` and `reference` with external script for performance.
+  * Many fixes, including contributions from:
+    * @N4M3Z
+    * @akatrevorjay
+    * @dotmpe
+    * @gaelicWizard
+    * @EmilySeville7cfg
+    * @junkblocker
+
+ 1.3   / 2015-11-04
 ==================
   * Make glossary() faster by not introspecting loaded shell functions
   * Remove brittle and incomplete test suite

--- a/README.md
+++ b/README.md
@@ -30,24 +30,19 @@ Please feel free to open an issue if you have any difficulties on your system.
 
 ## Installing
 
-Put composure.sh where you'd like it to live and source it from your
-shell's profile or rc file.
+Clone this repo, into a directory of your choice and source it from your shell's
+profile or rc file.
 
 On Bash:
 
 ```bash
     cd /your/favorite/directory
-    curl -L http://git.io/composure > composure.sh
-    chmod +x composure.sh
+    git clone https://github.com/erichs/composure.git
+    cd composure
     echo "source $(pwd)/composure.sh" >> ~/.bashrc   # or, ~/.bash_profile on osx
 ```
 
-Users upgrading from a version prior to 1.1.0 need to execute the following commands, as the directory for composure's local repo has changed:
-
-```bash
-  mkdir ~/.local 2>/dev/null
-  mv ~/.composure ~/.local/composure
-```
+Note for users with versions prior to 1.4.0: Previous installation methods will work, but cloning the repo is now recommended, as it makes the `glossary` and `reference` commands 100x faster.
 
 ## Craft - Draft - Revise - Write
 

--- a/composure.sh
+++ b/composure.sh
@@ -11,13 +11,26 @@
 # faster metadata lookups.
 # known to work on bash, zsh, and ksh93
 
-_composure_source_dir="$(dirname $(readlink -f ${BASH_SOURCE[0]}))"
-_composure_lookup_tool="${_composure_source_dir}/lookup.pl"
-
 # 'plumbing' functions
+
+_get_self_dir () {
+  # https://stackoverflow.com/questions/59895/how-can-i-get-the-source-directory-of-a-bash-script-from-within-the-script-itsel
+  # this appears to work across bash and zsh, but may not work on other shells :(
+  (
+    SCRIPT_DIR=''
+    pushd "$(dirname "$(readlink -f "$BASH_SOURCE")")" > /dev/null && {
+        SCRIPT_DIR="$PWD"
+        popd > /dev/null
+    }
+    echo "$SCRIPT_DIR"
+  )
+}
+
+_composure_lookup_tool="$(_get_self_dir)/lookup.pl"
 
 _bootstrap_composure() {
   _generate_metadata_functions
+  _persist_composure_functions
   _load_composed_functions
   _determine_printf_cmd
 }
@@ -242,6 +255,15 @@ _strip_semicolons () {
   sed -e 's/;$//'
 }
 
+_persist_composure_functions () {
+  typeset composure_dir="$(_get_composure_dir)"
+  if [ ! -d "$composure_dir" ]; then
+    return
+  fi
+  for func in cite draft glossary metafor reference revise write; do
+    typeset -f $func > "$composure_dir/${func}.inc"
+  done
+}
 
 # 'porcelain' functions
 

--- a/composure.sh
+++ b/composure.sh
@@ -18,15 +18,18 @@ _get_self_dir () {
   # this appears to work across bash and zsh, but may not work on other shells :(
   (
     SCRIPT_DIR=''
-    pushd "$(dirname "$(readlink -f "$BASH_SOURCE")")" > /dev/null && {
+    pushd "$(dirname "$(readlink -f "${BASH_SOURCE[0]}")")" > /dev/null && {
         SCRIPT_DIR="$PWD"
+        # shellcheck disable=SC2164
         popd > /dev/null
     }
     echo "$SCRIPT_DIR"
   )
 }
 
+# lookup tool expects to be in the same dir as this script.
 _composure_lookup_tool="$(_get_self_dir)/lookup.pl"
+_composure_dir="${XDG_DATA_HOME:-$HOME/.local}/composure"
 
 _bootstrap_composure() {
   _generate_metadata_functions
@@ -35,15 +38,10 @@ _bootstrap_composure() {
   _determine_printf_cmd
 }
 
-_get_composure_dir ()
-{
-    echo "${XDG_DATA_HOME:-$HOME/.local}/composure"
-}
-
 _get_author_name ()
 {
   typeset name localname
-  localname="$(git --git-dir "$(_get_composure_dir)/.git" config --get user.name)"
+  localname="$(git --git-dir "${_composure_dir}/.git" config --get user.name)"
   for name in "${GIT_AUTHOR_NAME:-}" "$localname"; do
     if [ -n "$name" ]; then
       echo "$name"
@@ -71,9 +69,9 @@ _letterpress ()
 
 _determine_printf_cmd() {
   if [ -z "${_printf_cmd:-}" ]; then
-    _printf_cmd=printf
+    _printf_cmd="printf"
     # prefer GNU gprintf if available
-    [ -x "$(which gprintf 2>/dev/null)" ] && _printf_cmd=gprintf
+    [ -x "$(which gprintf 2>/dev/null)" ] && _printf_cmd="gprintf"
     export _printf_cmd
   fi
 }
@@ -116,11 +114,10 @@ _add_composure_file ()
   typeset file="$2"
   typeset operation="$3"
   typeset comment="${4:-}"
-  typeset composure_dir=$(_get_composure_dir)
 
   (
-    if ! cd "$composure_dir"; then
-      printf "%s\n" "Oops! Can't find $composure_dir!"
+    if ! cd "${_composure_dir}"; then
+      printf "%s\n" "Oops! Can't find ${_composure_dir}!"
       return
     fi
     if git rev-parse 2>/dev/null; then
@@ -128,7 +125,7 @@ _add_composure_file ()
         printf "%s\n" "Oops! Couldn't find $file to version it for you..."
         return
       fi
-      cp "$file" "$composure_dir/$func.inc"
+      cp "$file" "${_composure_dir}/$func.inc"
       git add --all .
       if [ -z "$comment" ]; then
         comment="$(_prompt 'Git Comment: ')"
@@ -144,16 +141,15 @@ _transcribe ()
   typeset file="$2"
   typeset operation="$3"
   typeset comment="${4:-}"
-  typeset composure_dir=$(_get_composure_dir)
 
   if git --version >/dev/null 2>&1; then
-    if [ -d "$composure_dir" ]; then
+    if [ -d "$_composure_dir" ]; then
       _add_composure_file "$func" "$file" "$operation" "$comment"
     else
       if [ "${USE_COMPOSURE_REPO:-}" = "0" ]; then
         return  # if you say so...
       fi
-      printf "%s\n" "I see you don't have a $composure_dir repo..."
+      printf "%s\n" "I see you don't have a $_composure_dir repo..."
       typeset input=''
       typeset valid=0
       while [ $valid != 1 ]; do
@@ -163,8 +159,8 @@ _transcribe ()
           y|yes|Y|Yes|YES)
             (
               echo 'creating git repository for your functions...'
-              mkdir -p "$composure_dir" || return 1
-              cd "$composure_dir" || return 1
+              mkdir -p "$_composure_dir" || return 1
+              cd "$_composure_dir" || return 1
               git init
               echo "composure stores your function definitions here" > README.txt
               git add README.txt
@@ -227,8 +223,7 @@ _generate_metadata_functions() {
 }
 
 _list_composure_files () {
-  typeset composure_dir="$(_get_composure_dir)"
-  [ -d "$composure_dir" ] && find "$composure_dir" -maxdepth 1 -name '*.inc'
+  [ -d "$_composure_dir" ] && find "$_composure_dir" -maxdepth 1 -name '*.inc'
 }
 
 _load_composed_functions () {
@@ -256,12 +251,11 @@ _strip_semicolons () {
 }
 
 _persist_composure_functions () {
-  typeset composure_dir="$(_get_composure_dir)"
-  if [ ! -d "$composure_dir" ]; then
+  if [ ! -d "$_composure_dir" ]; then
     return
   fi
   for func in cite draft glossary metafor reference revise write; do
-    typeset -f $func > "$composure_dir/${func}.inc"
+    typeset -f "$func" > "${_composure_dir}/${func}.inc"
   done
 }
 
@@ -370,7 +364,8 @@ glossary ()
   typeset functionlist="$(_typeset_functions_about)"
   typeset maxwidth=$(_longest_function_name_length "$functionlist" | awk '{print $1 + 5}')
 
-  for func in $(echo $functionlist); do
+  # shellcheck disable=SC2116,SC2086  
+  for func in $(echo "$functionlist"); do
 
     if [ "X${targetgroup}X" != "XX" ]; then
       typeset group="$(typeset -f -- $func | metafor group)"
@@ -426,7 +421,7 @@ reference ()
   fi
 
   if [ -f "${_composure_lookup_tool}" ]; then
-    if [ ! -f "$(_get_composure_dir)/${func}.inc" ]; then
+    if [ ! -f "${_composure_dir}/${func}.inc" ]; then
       echo "Unknown function: $func. Try 'glossary' for a listing of available functions."
       return 1
     fi
@@ -439,27 +434,27 @@ reference ()
   typeset about="$(typeset -f "$func" | metafor about)"
   _letterpress "$about" "$func"
 
-  typeset author="$(typeset -f $func | metafor author)"
+  typeset author="$(typeset -f "$func" | metafor author)"
   if [ -n "$author" ]; then
     _letterpress "$author" 'author:'
   fi
 
-  typeset version="$(typeset -f $func | metafor version)"
+  typeset version="$(typeset -f "$func" | metafor version)"
   if [ -n "$version" ]; then
     _letterpress "$version" 'version:'
   fi
 
-  if [ -n "$(typeset -f $func | metafor param)" ]; then
+  if [ -n "$(typeset -f "$func" | metafor param)" ]; then
     printf "parameters:\n"
-    typeset -f $func | metafor param | while read -r line
+    typeset -f "$func" | metafor param | while read -r line
     do
       _letterpress "$line"
     done
   fi
 
-  if [ -n "$(typeset -f $func | metafor example)" ]; then
+  if [ -n "$(typeset -f "$func" | metafor example)" ]; then
     printf "examples:\n"
-    typeset -f $func | metafor example | while read -r line
+    typeset -f "$func" | metafor example | while read -r line
     do
       _letterpress "$line"
     done
@@ -491,20 +486,19 @@ revise ()
     return
   fi
 
-  typeset composure_dir=$(_get_composure_dir)
   typeset temp=$(_temp_filename_for revise)
   # populate tempfile...
-  if [ "$source" = 'env' ] || [ ! -f "$composure_dir/$func.inc" ]; then
+  if [ "$source" = 'env' ] || [ ! -f "${_composure_dir}/$func.inc" ]; then
     # ...with ENV if specified or not previously versioned
-    typeset -f $func >> $temp
+    typeset -f "$func" >> "$temp"
   else
     # ...or with contents of latest git revision
-    cat "$composure_dir/$func.inc" >> "$temp"
+    cat "${_composure_dir}/$func.inc" >> "$temp"
   fi
 
   if [ -z "${EDITOR:-}" ]
   then
-    typeset EDITOR=vi
+    typeset EDITOR="vi"
   fi
 
   $EDITOR "$temp"

--- a/lookup.pl
+++ b/lookup.pl
@@ -1,0 +1,134 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Term::ANSIColor;
+use v5.10.0;
+no warnings 'experimental';
+
+my $composurePath = ($ENV{'XDG_DATA_HOME'} || $ENV{'HOME'} . '/.local') . '/composure';
+my $referenceColor = $ENV{'COMPOSURE_REFERENCE_COLOR'} || 'bold bright_red';
+my @funcs = glob($composurePath . '/*.inc') or die "Cannot find composure files: $!";
+
+my %groupsSeen = ();
+my $groupFilter;
+
+sub main {
+  my $command = shift;
+  
+  my %actions = ( 
+    glossary => \&glossary,
+    reference => \&reference
+  );
+
+  $actions{$command}(@_) || die "Unknown command: $command";
+}
+
+sub glossary {
+  my $groupFilter = shift;
+  foreach my $func (@funcs) {
+    my ($name, $about, $groupsRef, undef, undef) = extract_metadata_from_file($func);
+
+    my %groupsHash = map { $_ => 1 } @$groupsRef;
+    if ($groupFilter && !exists($groupsHash{$groupFilter})) {
+      next;
+    }
+    if (!$about) {
+      $about = "No description provided.";
+    } 
+    print colorize($referenceColor, $name) . ": " . colorize('bright_white', $about) . "\n";
+  }
+
+  print colorize('bold bright_white', "\ngroups defined: ") . join(', ', sort(keys(%groupsSeen))) . "\n";
+  return 1;
+} 
+
+sub reference {
+  my $func = shift;
+  my $funcPath = $composurePath . '/' . $func . '.inc';
+  my ($name, $about, $groupsRef, $examplesRef, $paramsRef) = extract_metadata_from_file($funcPath);
+
+  say colorize($referenceColor, $name) . ": " . colorize('bright_white', $about);
+  if (scalar @$paramsRef > 0) {
+    say colorize('dark white', 'params:');
+    foreach my $param (@$paramsRef) {
+      say $param;
+    }
+  }
+  if (scalar @$examplesRef > 0) {
+    say colorize('dark white', 'examples:');
+    foreach my $example (@$examplesRef) {
+      say $example;
+    }
+  }
+  if (scalar @$groupsRef > 0) {
+    say colorize('dark white', 'groups') . ": " . join(' ', sort(@$groupsRef)) . "\n";
+  }
+  return 1;
+}
+
+sub rm_quotes {
+  my $str = shift;
+  return substr($str, 1, -1); # chop leading/trailing quote chars
+}
+
+sub extract_metadata_from_file {
+  my $file = shift;
+
+  open my $info, $file or die "Could not open $file: $!";
+  my $fname = (split('/', $file))[-1];
+  my $name = (split '.inc', $fname)[0];
+  my $about;
+  my @groups = ();
+  my @params = ();
+  my @examples = ();
+  my @chunks = ();
+  while (my $line = <$info>) {
+    chomp($line);
+    SWITCH: {
+      if ($line =~ /^\s*about /) {
+        @chunks = split /\s+/, $line;
+        $about = rm_quotes(join(' ', @chunks[2 .. $#chunks]));
+        last SWITCH;
+      }
+      if ($line =~ /^\s*group /) {
+        @chunks = split /\s+/, $line;
+        my $group = rm_quotes($chunks[2]);
+        if ($group =~ /\w+/) {
+          push(@groups, $group);
+          $groupsSeen{$group}++;
+        }
+        last SWITCH;
+      }
+      if ($line =~ /^\s*example /) {
+        @chunks = split /\s+/, $line;
+        my $example = rm_quotes(join(' ', @chunks[2 .. $#chunks]));
+        if ($example =~ /\w+/) {
+          push(@examples, $example);
+        }
+        last SWITCH;
+      }
+      if ($line =~ /^\s*param /) {
+        @chunks = split /\s+/, $line;
+        my $param = rm_quotes(join(' ', @chunks[2 .. $#chunks]));
+        if ($param =~ /\w+/) {
+          push(@params, $param);
+        }
+        last SWITCH;
+      }
+    }
+  }
+  close $info;
+  return ($name, $about, \@groups, \@examples, \@params);
+}
+
+sub colorize {
+  my $colorstr = shift;
+  my $text = shift;
+  # don't colorize if not attached to a terminal
+  if (! -t STDOUT) {
+    return $text;
+  }
+  return color($colorstr) . $text . color('reset');
+}
+
+main @ARGV


### PR DESCRIPTION
This release offloads metadata lookup (`glossary` and `reference` functions) to an external script for a massive performance improvement.

Preferred installation is now cloning this repo (or otherwise managing to put `lookup.pl` and `composure.sh` in the same dir/folder somewhere convenient.

If present, the `lookup.pl` utility will be used, otherwise it will fall back to the previous behavior, which is now deprecated and likely to be removed in a future release.

Includes various other fixes and linting improvements.